### PR TITLE
remove obsolete key in demo app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+TCSample.iml
 target/
 .idea/
 \.vscode/

--- a/src/main/java/totalcross/sample/TCSampleApplication.java
+++ b/src/main/java/totalcross/sample/TCSampleApplication.java
@@ -6,6 +6,10 @@ import totalcross.sample.main.TCSample;
 public class TCSampleApplication {
 	public static void main(String[] args) {
 	    TotalCrossApplication.run(
-	        TCSample.class, "/r", "<PLACE YOUR KEY>", "/scr", "iphone");
+				TCSample.class,"/scr", "iphone"
+		);
+	    // Note: for a pre-6.1 launcher, the command line should be like:
+		//	  TCSample.class, "/r", "<PLACE YOUR KEY>", "/scr", "iphone"
+
 	  }
 }


### PR DESCRIPTION
Simplify the demo app, right now it hints that a key should be present, while it's not required any more